### PR TITLE
[PAGOPA-1109] Authorizer - Adding metadata on authorization strings

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - Enrolled EC",
-    "version": "0.2.0"
+    "version": "0.2.0-1"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.authorizer</groupId>
     <artifactId>platform-authorizer</artifactId>
-    <version>0.2.0</version>
+    <version>0.2.0-1</version>
     <packaging>jar</packaging>
 
     <name>Azure Authorizer cache Fn</name>

--- a/src/main/java/it/gov/pagopa/authorizer/model/AuthConfiguration.java
+++ b/src/main/java/it/gov/pagopa/authorizer/model/AuthConfiguration.java
@@ -8,4 +8,5 @@ import lombok.*;
 public class AuthConfiguration {
     private String key;
     private String value;
+    private String metadata;
 }

--- a/src/main/java/it/gov/pagopa/authorizer/service/CacheService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/service/CacheService.java
@@ -45,7 +45,8 @@ public class CacheService {
                     .collect(Collectors.toList());
             AuthConfiguration authConfiguration = AuthConfiguration.builder()
                     .key(String.format(Constants.AUTH_CONFIGURATION_KEY_FORMAT, domain, subkeyDomain.getSubkey()))
-                    .value(Utility.convertListToString(authorizedEntities, ","))
+                    .value(Utility.convertListToString(authorizedEntities, "#"))
+                    .metadata(Utility.extractMetadataAsString(subkeyDomain.getOtherMetadata()))
                     .build();
             this.logger.log(Level.INFO, () -> String.format("The record with id [%s] related to the subscription key associated to the domain [%s] has triggered the execution. Will be added the following entities: [%s]", subkeyDomain.getId(), subkeyDomain.getDomain(), authConfiguration.getValue()));
 

--- a/src/main/java/it/gov/pagopa/authorizer/util/Utility.java
+++ b/src/main/java/it/gov/pagopa/authorizer/util/Utility.java
@@ -1,5 +1,10 @@
 package it.gov.pagopa.authorizer.util;
 
+import it.gov.pagopa.authorizer.entity.GenericPair;
+import it.gov.pagopa.authorizer.entity.Metadata;
+import lombok.NonNull;
+import org.apache.commons.lang3.StringUtils;
+
 import java.util.*;
 
 public class Utility {
@@ -29,5 +34,34 @@ public class Utility {
             }
         }
         return builder.toString();
+    }
+
+    public static String extractMetadataAsString(@NonNull List<Metadata> metadata) {
+        StringBuilder builder = new StringBuilder();
+        for (Metadata singleMetadata : metadata) {
+            builder.append(singleMetadata.getShortKey()).append("=");
+            List<GenericPair> content = singleMetadata.getContent();
+            if (content.size() == 1) {
+                GenericPair metadataPair = content.get(0);
+                builder.append(getMetadataValueAsString(metadataPair));
+            } else {
+                Iterator<GenericPair> it = content.iterator();
+                while (it.hasNext()) {
+                    GenericPair metadataPair = it.next();
+                    builder.append(metadataPair.getKey()).append(":");
+                    builder.append(getMetadataValueAsString(metadataPair));
+                    if (it.hasNext()) {
+                        builder.append(";");
+                    }
+                }
+            }
+            builder.append(";;");
+        }
+
+        return builder.toString();
+    }
+
+    private static String getMetadataValueAsString(GenericPair metadataPair) {
+        return metadataPair.getValues() != null ? StringUtils.join(metadataPair.getValues(), ",") : metadataPair.getValue();
     }
 }

--- a/src/test/java/it/gov/pagopa/authorizer/service/CacheServiceTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/service/CacheServiceTest.java
@@ -9,6 +9,8 @@ import it.gov.pagopa.authorizer.util.ResponseSubscriber;
 import lombok.SneakyThrows;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.exceptions.base.MockitoException;
@@ -41,57 +43,17 @@ class CacheServiceTest {
     HttpClient httpClient;
 
     @SneakyThrows
-    @Test
-    void addAuthConfigurationToAPIMAuthorizer_OK() {
+    @ParameterizedTest
+    @CsvSource(delimiterString = "/", value = {
+            "0/{\"key\":\"domain_1\",\"value\":\"entity1#entity2#entity3\",\"metadata\":\"_o=pagoPA;;\"}",
+            "1/{\"key\":\"domain_1\",\"value\":\"entity1#entity2|sub-entity\",\"metadata\":\"_o=pagoPA;;\"}",
+            "3/{\"key\":\"domain_1\",\"value\":\"entity1#entity2#entity3\",\"metadata\":\"\"}"
+    })
+    void addAuthConfigurationToAPIMAuthorizer_OK(int id, String subkeyDomainAsString) {
 
         // Mocking passed values
-        SubscriptionKeyDomain subkeyDomain = getSubscriptionKeyDomains().get(0);
-        String subkeyDomainAsString = "{\"key\":\"domain_1\",\"value\":\"entity1#entity2#entity3\",\"metadata\":\"_o=pagoPA;;\"}";
-        MockHttpResponse mockedHttpResponse = MockHttpResponse.builder().statusCode(200).uri(new URI("")).build();
-
-        // Mocking execution for service's internal component
-        CacheService cacheService = spy(new CacheService(logger, httpClient, AUTHORIZER_PATH));
-        doReturn(mockedHttpResponse).when(httpClient).send(any(), any());
-
-        // Execute function
-        cacheService.addAuthConfigurationToAPIMAuthorizer(subkeyDomain, false);
-
-        // Checking assertions
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(httpClient, times(1)).send(requestCaptor.capture(), any());
-        assertEquals(subkeyDomainAsString, extractRequestMadeToAPIM(requestCaptor));
-    }
-
-
-    @SneakyThrows
-    @Test
-    void addAuthConfigurationToAPIMAuthorizer_OK_compositeEntity() {
-
-        // Mocking passed values
-        SubscriptionKeyDomain subkeyDomain = getSubscriptionKeyDomains().get(1);
-        String subkeyDomainAsString = "{\"key\":\"domain_1\",\"value\":\"entity1#entity2|sub-entity\",\"metadata\":\"_o=pagoPA;;\"}";
-        MockHttpResponse mockedHttpResponse = MockHttpResponse.builder().statusCode(200).uri(new URI("")).build();
-
-        // Mocking execution for service's internal component
-        CacheService cacheService = spy(new CacheService(logger, httpClient, AUTHORIZER_PATH));
-        doReturn(mockedHttpResponse).when(httpClient).send(any(), any());
-
-        // Execute function
-        cacheService.addAuthConfigurationToAPIMAuthorizer(subkeyDomain, false);
-
-        // Checking assertions
-        ArgumentCaptor<HttpRequest> requestCaptor = ArgumentCaptor.forClass(HttpRequest.class);
-        verify(httpClient, times(1)).send(requestCaptor.capture(), any());
-        assertEquals(subkeyDomainAsString, extractRequestMadeToAPIM(requestCaptor));
-    }
-
-    @SneakyThrows
-    @Test
-    void addAuthConfigurationToAPIMAuthorizer_OK_emptyMetadata() {
-
-        // Mocking passed values
-        SubscriptionKeyDomain subkeyDomain = getSubscriptionKeyDomains().get(3);
-        String subkeyDomainAsString = "{\"key\":\"domain_1\",\"value\":\"entity1#entity2#entity3\",\"metadata\":\"\"}";
+        SubscriptionKeyDomain subkeyDomain = getSubscriptionKeyDomains().get(id);
+        //String subkeyDomainAsString = "{\"key\":\"domain_1\",\"value\":\"entity1#entity2#entity3\",\"metadata\":\"_o=pagoPA;;\"}";
         MockHttpResponse mockedHttpResponse = MockHttpResponse.builder().statusCode(200).uri(new URI("")).build();
 
         // Mocking execution for service's internal component

--- a/src/test/java/it/gov/pagopa/authorizer/util/UtilityTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/util/UtilityTest.java
@@ -1,5 +1,7 @@
 package it.gov.pagopa.authorizer.util;
 
+import it.gov.pagopa.authorizer.entity.GenericPair;
+import it.gov.pagopa.authorizer.entity.Metadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -57,5 +59,46 @@ class UtilityTest {
         assertThrows(IllegalArgumentException.class, () -> Utility.convertListToString(null, FIRST_SEPARATOR));
         assertThrows(IllegalArgumentException.class, () -> Utility.convertListToString(contentList, null, false));
         assertThrows(IllegalArgumentException.class, () -> Utility.convertListToString(contentList, null));
+    }
+
+    @Test
+    void extractMetadataAsString_OK() {
+        String expectedResult = "_md1=single-value;;_md2=value1,value2;;_md3=multiple-object-1:single-value;multiple-object-2:value1,value2;;";
+        List<Metadata> metadata = List.of(
+                Metadata.builder()
+                        .name("metadata-1")
+                        .shortKey("_md1")
+                        .content(List.of(
+                                GenericPair.builder()
+                                        .key("single-object")
+                                        .value("single-value")
+                                        .build()))
+                        .build(),
+                Metadata.builder()
+                        .name("metadata-2")
+                        .shortKey("_md2")
+                        .content(List.of(
+                                GenericPair.builder()
+                                        .key("single-object-with-multiple-values")
+                                        .values(List.of("value1", "value2"))
+                                        .build()))
+                        .build(),
+                Metadata.builder()
+                        .name("metadata-3")
+                        .shortKey("_md3")
+                        .content(List.of(
+                                GenericPair.builder()
+                                        .key("multiple-object-1")
+                                        .value("single-value")
+                                        .build(),
+                                GenericPair.builder()
+                                        .key("multiple-object-2")
+                                        .values(List.of("value1", "value2"))
+                                        .build()))
+                        .build()
+        );
+
+        String result = Utility.extractMetadataAsString(metadata);
+        assertEquals(expectedResult, result);
     }
 }

--- a/src/test/java/it/gov/pagopa/authorizer/util/UtilityTest.java
+++ b/src/test/java/it/gov/pagopa/authorizer/util/UtilityTest.java
@@ -5,6 +5,7 @@ import it.gov.pagopa.authorizer.entity.Metadata;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -64,7 +65,17 @@ class UtilityTest {
     @Test
     void extractMetadataAsString_OK() {
         String expectedResult = "_md1=single-value;;_md2=value1,value2;;_md3=multiple-object-1:single-value;multiple-object-2:value1,value2;;";
-        List<Metadata> metadata = List.of(
+        String result = Utility.extractMetadataAsString(getMetadataList());
+        assertEquals(expectedResult, result);
+    }
+
+    @Test
+    void extractMetadataAsString_KO() {
+        assertThrows(Exception.class, () -> Utility.extractMetadataAsString(null));
+    }
+
+    private static List<Metadata> getMetadataList() {
+        return List.of(
                 Metadata.builder()
                         .name("metadata-1")
                         .shortKey("_md1")
@@ -97,8 +108,5 @@ class UtilityTest {
                                         .build()))
                         .build()
         );
-
-        String result = Utility.extractMetadataAsString(metadata);
-        assertEquals(expectedResult, result);
     }
 }


### PR DESCRIPTION
This PR contains all the update made in order to include the metadata information in the request to be passed to the Authorizer Policy-based's API. The inclusion of the metadata is required in order to save these information in the cached authorization string.  
Other update made in this PR are related to a better optimization of the whole system (for example, replacing the comma with the hash character in order to remove a intermediate step of replacing in the Authorizer Policy-based's API).

#### List of Changes
 - Added metadata information on the request for Authorizer Policy-based's API.
 - Changed data passed as input for the requests on Authorizer Policy-based's API.

#### Motivation and Context
These changes are required in order to permit the caching of the metadata in the authorization string.

#### How Has This Been Tested?
 - Tested in DEV environment

#### Screenshots (if appropriate):

#### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.