### PR TITLE
[PAGOPA-1203] Bug on forced update

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - Enrolled EC",
-    "version": "0.2.0-2"
+    "version": "0.2.0-3"
   },
   "servers": [
     {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -2,7 +2,7 @@
   "openapi": "3.0.1",
   "info": {
     "title": "OpenAPI definition - Enrolled EC",
-    "version": "0.2.0-1"
+    "version": "0.2.0-2"
   },
   "servers": [
     {

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.authorizer</groupId>
     <artifactId>platform-authorizer</artifactId>
-    <version>0.2.0-2</version>
+    <version>0.2.0-3</version>
     <packaging>jar</packaging>
 
     <name>Azure Authorizer cache Fn</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
     <groupId>it.gov.pagopa.authorizer</groupId>
     <artifactId>platform-authorizer</artifactId>
-    <version>0.2.0-1</version>
+    <version>0.2.0-2</version>
     <packaging>jar</packaging>
 
     <name>Azure Authorizer cache Fn</name>

--- a/src/main/java/it/gov/pagopa/authorizer/CacheNotifier.java
+++ b/src/main/java/it/gov/pagopa/authorizer/CacheNotifier.java
@@ -8,6 +8,7 @@ import it.gov.pagopa.authorizer.util.Constants;
 
 import java.net.http.HttpClient;
 import java.net.http.HttpResponse;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
@@ -31,15 +32,53 @@ public class CacheNotifier {
             final ExecutionContext context) throws InterruptedException {
 
         Logger logger = context.getLogger();
-        HttpResponse<String> responseContent = null;
+        List<SubscriptionKeyDomain> unprocessedSubkeyDomains = List.copyOf(triggeredSubkeyDomains);
 
-        for (SubscriptionKeyDomain triggeredSubkeyDomain : triggeredSubkeyDomains) {
-            this.getCacheService(logger).addAuthConfigurationToAPIMAuthorizer(triggeredSubkeyDomain, true);
+        boolean executeStep = true;
+        int retry = 1;
+        int maxRetries = getRetryNumber();
+        long retryDelay = getStartingRetryDelay();
+
+        final long startingRetryDelayLog = retryDelay;
+        logger.log(Level.INFO, () -> String.format("The execution of cache generation from DB trigger will be executed. Max retries: [%d], starting delay on exponential back-off: [%d].", maxRetries, startingRetryDelayLog));
+
+        // retry the execution until all request are cached or until there are made a number of retries equals to the max value
+        while (executeStep) {
+
+            // executing main task of caching authorizations
+            List<SubscriptionKeyDomain> toBeRetried = new LinkedList<>();
+            for (SubscriptionKeyDomain unprocessedSubkeyDomain : unprocessedSubkeyDomains) {
+                HttpResponse<String> response = this.getCacheService(logger).addAuthConfigurationToAPIMAuthorizer(unprocessedSubkeyDomain, true);
+                if (response.statusCode() != 200) {
+                    toBeRetried.add(unprocessedSubkeyDomain);
+                }
+            }
+
+            // setting the next retry step if something went wrong
+            executeStep = !toBeRetried.isEmpty() && retry < maxRetries;
+            if (executeStep) {
+                retryDelay = (long) (retryDelay * (Math.pow(2.0, retry++)));
+                final long retryDelayLog = retryDelay;
+                logger.log(Level.INFO, () -> String.format("There are [%d] authorizations that were not correctly cached. Retrying the execution, waiting [%s] ms.", toBeRetried.size(), retryDelayLog));
+                unprocessedSubkeyDomains = toBeRetried;
+                Thread.sleep(retryDelay);
+            }
         }
+
         logger.log(Level.INFO, () -> "The execution of cache generation from DB trigger is ended.");
     }
 
     public CacheService getCacheService(Logger logger) {
         return new CacheService(logger, HttpClient.newHttpClient(), authorizerPath);
+    }
+
+    public int getRetryNumber() {
+        String retries = System.getenv(Constants.RETRY_NUMBER_PARAMETER);
+        return retries != null ? Integer.parseInt(retries) : Constants.RETRY_NUMBER_PARAMETER_DEFAULT;
+    }
+
+    public int getStartingRetryDelay() {
+        String retries = System.getenv(Constants.STARTING_RETRY_DELAY_MILLIS_PARAMETER);
+        return retries != null ? Integer.parseInt(retries) : Constants.STARTING_RETRY_DELAY_MILLIS_PARAMETER_DEFAULT;
     }
 }

--- a/src/main/java/it/gov/pagopa/authorizer/CacheNotifier.java
+++ b/src/main/java/it/gov/pagopa/authorizer/CacheNotifier.java
@@ -34,10 +34,9 @@ public class CacheNotifier {
         HttpResponse<String> responseContent = null;
 
         for (SubscriptionKeyDomain triggeredSubkeyDomain : triggeredSubkeyDomains) {
-            responseContent = this.getCacheService(logger).addAuthConfigurationToAPIMAuthorizer(triggeredSubkeyDomain, true);
+            this.getCacheService(logger).addAuthConfigurationToAPIMAuthorizer(triggeredSubkeyDomain, true);
         }
-        final int statusCode = responseContent != null ? responseContent.statusCode() : 500;
-        logger.log(Level.INFO, () -> String.format("The execution will end with an HTTP status code %s", statusCode));
+        logger.log(Level.INFO, () -> "The execution of cache generation from DB trigger is ended.");
     }
 
     public CacheService getCacheService(Logger logger) {

--- a/src/main/java/it/gov/pagopa/authorizer/service/CacheService.java
+++ b/src/main/java/it/gov/pagopa/authorizer/service/CacheService.java
@@ -48,7 +48,7 @@ public class CacheService {
                     .value(Utility.convertListToString(authorizedEntities, "#"))
                     .metadata(Utility.extractMetadataAsString(subkeyDomain.getOtherMetadata()))
                     .build();
-            this.logger.log(Level.INFO, () -> String.format("The record with id [%s] related to the subscription key associated to the domain [%s] has triggered the execution. Will be added the following entities: [%s]", subkeyDomain.getId(), subkeyDomain.getDomain(), authConfiguration.getValue()));
+            this.logger.log(Level.INFO, () -> String.format("The record with id [%s] related to the subscription key associated to the domain [%s] has triggered the execution. The following entities will be added: [%s]", subkeyDomain.getId(), subkeyDomain.getDomain(), authConfiguration.getValue()));
 
             // executing the request towards APIM Authorizer's API
             String refactoredAuthorizerPath = String.format(Constants.AUTH_REFRESH_CONFIGURATION_PATH_TEMPLATE, this.authorizerPath, addInProgress).replace("{domain}", domain);
@@ -59,6 +59,8 @@ public class CacheService {
                     .POST(HttpRequest.BodyPublishers.ofString(new ObjectMapper().writeValueAsString(authConfiguration)))
                     .build();
             response = this.httpClient.send(apimRequest, HttpResponse.BodyHandlers.ofString());
+            final int statusCode = response != null ? response.statusCode() : 500;
+            logger.log(Level.INFO, () -> String.format("The execution of the record with id [%s] will end with an HTTP status code %s", subkeyDomain.getId(), statusCode));
 
         } catch (URISyntaxException | IOException e) {
             this.logger.log(Level.SEVERE, "An error occurred while trying to calling APIM's Authorizer API. The communication with APIM's API failed. ", e);

--- a/src/main/java/it/gov/pagopa/authorizer/util/Constants.java
+++ b/src/main/java/it/gov/pagopa/authorizer/util/Constants.java
@@ -16,7 +16,16 @@ public class Constants {
 
     public static final String APICONFIG_SELFCARE_INTEGRATION_SUBKEY_PARAMETER = "APICONFIG_SELFCARE_INTEGRATION_SUBKEY";
 
+    public static final String RETRY_NUMBER_PARAMETER = "RETRY_NUMBER";
+
+    public static final int RETRY_NUMBER_PARAMETER_DEFAULT = 1;
+
+    public static final String STARTING_RETRY_DELAY_MILLIS_PARAMETER = "STARTING_RETRY_DELAY_MILLIS";
+
+    public static final int STARTING_RETRY_DELAY_MILLIS_PARAMETER_DEFAULT = 1000;
+
     public static final String WILDCARD_CHARACTER = "*";
+
 
     public static final Map<String, String> DOMAIN_TO_SERVICE_URI_MAPPING = Map.ofEntries(
             // insert here other static mapping from domain to service URI


### PR DESCRIPTION
This PR contains several changes related to the definition of a retry handling logic on CacheNotifier Function in order to resolve a bug related to `cache-remove-value` instruction on cache operation's APIM policy.  

#### List of Changes
 - Added retry logic on CacheNotifier function
 - Updated logs for more verbose description of the flow
 - Updated JUnit tests

#### Motivation and Context
These changes are required in order to resolve the bug related to the operation of forced refresh.

#### How Has This Been Tested?
- Tested in DEV environment
- Tested in UAT environment

#### Screenshots (if appropriate):

#### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

#### Checklist:
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.